### PR TITLE
Add payment timeout and refund protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ ZenithPay enables fast and secure international payments using Bitcoin as the se
 - Manage transaction fees
 - Handle payment disputes and timeouts
 - Query payment status and history
+- Automatic payment refunds after timeout period
 
 ## Getting Started
 
@@ -27,3 +28,11 @@ ZenithPay enables fast and secure international payments using Bitcoin as the se
 2. Initialize a payment channel
 3. Register Bitcoin addresses
 4. Execute payments through the channel
+
+## Payment Protection
+
+The contract now includes a timeout mechanism that protects senders from unresponsive receivers:
+
+- When a payment is executed, a 144-block timeout period begins (~24 hours)
+- If the receiver doesn't confirm the payment within this period, the sender can reclaim their funds
+- This prevents funds from being locked indefinitely in case of receiver inaction

--- a/tests/zenith_pay_test.ts
+++ b/tests/zenith_pay_test.ts
@@ -110,3 +110,54 @@ Clarinet.test({
     assertEquals(channelInfo.result.expectSome()['balance'], types.uint(1000000));
   }
 });
+
+Clarinet.test({
+  name: "Test payment refund after timeout",
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    const deployer = accounts.get('deployer')!;
+    const wallet1 = accounts.get('wallet_1')!;
+    
+    // Create channel
+    let block1 = chain.mineBlock([
+      Tx.contractCall('zenith-pay', 'create-channel', [
+        types.principal(wallet1.address),
+        types.uint(2000000)
+      ], deployer.address)
+    ]);
+    
+    const channelId = block1.receipts[0].result.expectOk().expectUint();
+    
+    // Execute payment
+    let block2 = chain.mineBlock([
+      Tx.contractCall('zenith-pay', 'execute-payment', [
+        types.uint(channelId),
+        types.uint(1000000)
+      ], deployer.address)
+    ]);
+    
+    block2.receipts[0].result.expectOk();
+    
+    // Mine 144 blocks to pass timeout
+    chain.mineEmptyBlockUntil(chain.blockHeight + 144);
+    
+    // Attempt refund
+    let block3 = chain.mineBlock([
+      Tx.contractCall('zenith-pay', 'refund-payment', [
+        types.uint(channelId)
+      ], deployer.address)
+    ]);
+    
+    block3.receipts[0].result.expectOk();
+    
+    // Verify final state
+    let channelInfo = chain.callReadOnlyFn(
+      'zenith-pay',
+      'get-channel-info',
+      [types.uint(channelId)],
+      deployer.address
+    );
+    
+    assertEquals(channelInfo.result.expectSome()['state'], "ACTIVE");
+    assertEquals(channelInfo.result.expectSome()['timeout'], types.uint(0));
+  }
+});


### PR DESCRIPTION
This PR adds a critical protection mechanism to the payment system by implementing timeouts and refunds for pending payments.

Changes:
- Added timeout tracking to payment channels
- Implemented refund-payment function that allows senders to reclaim funds after timeout
- Set timeout period to 144 blocks (~24 hours) after payment execution
- Added new error code for invalid refund attempts
- Extended test coverage to verify refund functionality
- Updated documentation

The enhancement addresses a key vulnerability where funds could be locked indefinitely if a receiver becomes unresponsive. Now, senders have recourse to recover their funds after a reasonable waiting period.

Impact:
- No breaking changes to existing functionality
- Improved security and usability for payment senders
- Better alignment with common payment channel patterns
- Enhanced protection against malicious or inactive receivers

Testing:
- Added comprehensive test cases for timeout and refund scenarios
- Verified backward compatibility
- Confirmed proper state transitions during refund process